### PR TITLE
fix json invalid payload message type

### DIFF
--- a/api.py
+++ b/api.py
@@ -42,7 +42,7 @@ def publish():
     try:
         data = json.loads(payload)
     except:
-        return {'error':'invalid payload'}
+        return jsonify({'error':'invalid payload'})
 
     def notify():
         msg = str(time.time())


### PR DESCRIPTION
invalid payload message is now encoded as JSON object rather than treated as dict, which throws errors on some machines.